### PR TITLE
Add/global freeze

### DIFF
--- a/src/Curve.sol
+++ b/src/Curve.sol
@@ -320,6 +320,11 @@ contract Curve is Storage, MerkleProver, NoDelegateCall {
         _;
     }
 
+    modifier globallyTransactable() {
+        require(ICurveFactory(address(curveFactory)).getGlobalTransactableState(), "Curve/frozen-globally-only-allowing-proportional-withdraw");
+        _;
+    }
+
     constructor(
         string memory _name,
         string memory _symbol,
@@ -423,7 +428,7 @@ contract Curve is Storage, MerkleProver, NoDelegateCall {
         uint256 _originAmount,
         uint256 _minTargetAmount,
         uint256 _deadline
-    ) external deadline(_deadline) transactable noDelegateCall isNotEmergency nonReentrant returns (uint256 targetAmount_) {
+    ) external deadline(_deadline) globallyTransactable transactable noDelegateCall isNotEmergency nonReentrant returns (uint256 targetAmount_) {
         OriginSwapData memory _swapData;
         _swapData._origin = _origin;
         _swapData._target = _target;
@@ -445,7 +450,7 @@ contract Curve is Storage, MerkleProver, NoDelegateCall {
         address _origin,
         address _target,
         uint256 _originAmount
-    ) external view transactable returns (uint256 targetAmount_) {
+    ) external view globallyTransactable transactable returns (uint256 targetAmount_) {
         targetAmount_ = Swaps.viewOriginSwap(curve, _origin, _target, _originAmount);
     }
 
@@ -462,7 +467,7 @@ contract Curve is Storage, MerkleProver, NoDelegateCall {
         uint256 _maxOriginAmount,
         uint256 _targetAmount,
         uint256 _deadline
-    ) external deadline(_deadline) transactable noDelegateCall isNotEmergency nonReentrant returns (uint256 originAmount_) {
+    ) external deadline(_deadline) globallyTransactable transactable noDelegateCall isNotEmergency nonReentrant returns (uint256 originAmount_) {
         TargetSwapData memory _swapData;
         _swapData._origin = _origin;
         _swapData._target = _target;
@@ -484,7 +489,7 @@ contract Curve is Storage, MerkleProver, NoDelegateCall {
         address _origin,
         address _target,
         uint256 _targetAmount
-    ) external view transactable returns (uint256 originAmount_) {
+    ) external view globallyTransactable transactable returns (uint256 originAmount_) {
         originAmount_ = Swaps.viewTargetSwap(curve, _origin, _target, _targetAmount);
     }
 
@@ -504,7 +509,7 @@ contract Curve is Storage, MerkleProver, NoDelegateCall {
         bytes32[] calldata merkleProof,
         uint256 _deposit,
         uint256 _deadline
-    ) external deadline(_deadline) transactable nonReentrant noDelegateCall inWhitelistingStage returns (uint256, uint256[] memory) {
+    ) external deadline(_deadline) globallyTransactable transactable nonReentrant noDelegateCall inWhitelistingStage returns (uint256, uint256[] memory) {
         require(amount == 1, "Curve/invalid-amount");
         require(index <= 473, "Curve/index-out-of-range" );
         require(isWhitelisted(index, account, amount, merkleProof), "Curve/not-whitelisted");
@@ -531,6 +536,7 @@ contract Curve is Storage, MerkleProver, NoDelegateCall {
     function deposit(uint256 _deposit, uint256 _deadline)
         external
         deadline(_deadline)
+        globallyTransactable
         transactable
         nonReentrant
         noDelegateCall
@@ -547,7 +553,7 @@ contract Curve is Storage, MerkleProver, NoDelegateCall {
     ///                 prevailing proportions of the numeraire assets of the pool
     /// @return (the amount of curves you receive in return for your deposit,
     ///          the amount deposited for each numeraire)
-    function viewDeposit(uint256 _deposit) external view transactable returns (uint256, uint256[] memory) {
+    function viewDeposit(uint256 _deposit) external view globallyTransactable transactable returns (uint256, uint256[] memory) {
         // curvesToMint_, depositsToMake_
         return ProportionalLiquidity.viewProportionalDeposit(curve, _deposit);
     }
@@ -591,7 +597,7 @@ contract Curve is Storage, MerkleProver, NoDelegateCall {
     /// @param   _curvesToBurn the full amount you want to withdraw from the pool which will be withdrawn from evenly amongst the
     ///                        numeraire assets of the pool
     /// @return the amonnts of numeraire assets withdrawn from the pool
-    function viewWithdraw(uint256 _curvesToBurn) external view transactable returns (uint256[] memory) {
+    function viewWithdraw(uint256 _curvesToBurn) external view globallyTransactable transactable returns (uint256[] memory) {
         return ProportionalLiquidity.viewProportionalWithdraw(curve, _curvesToBurn);
     }
 
@@ -636,7 +642,7 @@ contract Curve is Storage, MerkleProver, NoDelegateCall {
         uint256 amount0,
         uint256 amount1,
         bytes calldata data
-    ) external transactable noDelegateCall isNotEmergency {
+    ) external globallyTransactable transactable noDelegateCall isNotEmergency {
         uint256 fee = curve.epsilon.mulu(1e18);
         
         require(IERC20(derivatives[0]).balanceOf(address(this)) > 0, 'Curve/token0-zero-liquidity-depth');

--- a/src/Curve.sol
+++ b/src/Curve.sol
@@ -321,7 +321,7 @@ contract Curve is Storage, MerkleProver, NoDelegateCall {
     }
 
     modifier globallyTransactable() {
-        require(ICurveFactory(address(curveFactory)).getGlobalTransactableState(), "Curve/frozen-globally-only-allowing-proportional-withdraw");
+        require(!ICurveFactory(address(curveFactory)).getGlobalFrozenState(), "Curve/frozen-globally-only-allowing-proportional-withdraw");
         _;
     }
 

--- a/src/CurveFactoryV2.sol
+++ b/src/CurveFactoryV2.sol
@@ -79,7 +79,7 @@ contract CurveFactoryV2 is ICurveFactory, Ownable {
     function setGlobalFrozen(bool _toFreezeOrNotToFreeze) external onlyOwner {
         emit GlobalFrozenSet(_toFreezeOrNotToFreeze);
 
-        globalFrozen = _toFlashOrNotToFlash;
+        globalFrozen = _toFreezeOrNotToFreeze;
     }
 
     function updateProtocolTreasury(address _newTreasury) external onlyOwner {

--- a/src/CurveFactoryV2.sol
+++ b/src/CurveFactoryV2.sol
@@ -39,6 +39,10 @@ contract CurveFactoryV2 is ICurveFactory, Ownable {
     int128 public protocolFee;
     address public protocolTreasury;
 
+    // Global curve operational state
+    bool public globalFrozen = false;
+
+    event GlobalFrozenSet(bool isFrozen);
     event TreasuryUpdated(address indexed newTreasury);
     event ProtocolFeeUpdated(address indexed treasury, int128 indexed fee);
 
@@ -60,12 +64,22 @@ contract CurveFactoryV2 is ICurveFactory, Ownable {
         assimilatorFactory = IAssimilatorFactory(_assimFactory);
     }
 
+    function getGlobalFrozenState() external view virtual override returns (bool) {
+        return globalFrozen;
+    }
+
     function getProtocolFee() external view virtual override returns (int128) {
         return protocolFee;
     }
 
     function getProtocolTreasury() external view virtual override returns (address) {
         return protocolTreasury;
+    }
+
+    function setGlobalFrozen(bool _toFreezeOrNotToFreeze) external onlyOwner {
+        emit GlobalFrozenSet(_toFreezeOrNotToFreeze);
+
+        globalFrozen = _toFlashOrNotToFlash;
     }
 
     function updateProtocolTreasury(address _newTreasury) external onlyOwner {

--- a/src/interfaces/ICurve.sol
+++ b/src/interfaces/ICurve.sol
@@ -2,6 +2,8 @@
 pragma solidity ^0.8.13;
 
 interface ICurve {
+    function viewDeposit(uint256 deposit) external view returns (uint256, uint256[] memory);
+    function deposit(uint256 deposit, uint256 deadline) external;
     function flash(address recipient, uint256 amount0, uint256 amount1, bytes calldata data) external;
     function derivatives(uint256) external view returns (address);
 }

--- a/src/interfaces/ICurveFactory.sol
+++ b/src/interfaces/ICurveFactory.sol
@@ -5,4 +5,5 @@ interface ICurveFactory {
     function getProtocolFee() external view returns (int128);
     function getProtocolTreasury() external view returns (address);
     function getGlobalFrozenState() external view returns (bool);
+    function setGlobalFrozen(bool) external;
 }

--- a/src/interfaces/ICurveFactory.sol
+++ b/src/interfaces/ICurveFactory.sol
@@ -3,6 +3,6 @@ pragma solidity ^0.8.13;
 
 interface ICurveFactory {
     function getProtocolFee() external view returns (int128);
-
     function getProtocolTreasury() external view returns (address);
+    function getGlobalTransactableState() external view returns (address);
 }

--- a/src/interfaces/ICurveFactory.sol
+++ b/src/interfaces/ICurveFactory.sol
@@ -4,5 +4,5 @@ pragma solidity ^0.8.13;
 interface ICurveFactory {
     function getProtocolFee() external view returns (int128);
     function getProtocolTreasury() external view returns (address);
-    function getGlobalTransactableState() external view returns (address);
+    function getGlobalFrozenState() external view returns (bool);
 }

--- a/test/CurveFactoryV2.t.sol
+++ b/test/CurveFactoryV2.t.sol
@@ -17,6 +17,7 @@ contract CurveFactoryV2Test is Test {
     CheatCodes cheats = CheatCodes(HEVM_ADDRESS);
     MockUser treasury;
     MockUser newTreasury;
+    MockUser liquidityProvider;
 
     AssimilatorFactory assimilatorFactory;
     CurveFactoryV2 curveFactory;
@@ -37,6 +38,7 @@ contract CurveFactoryV2Test is Test {
     function setUp() public {
         treasury = new MockUser();
         newTreasury = new MockUser();
+        liquidityProvider = new MockUser();
 
         assimilatorFactory = new AssimilatorFactory();
         curveFactory = new CurveFactoryV2(
@@ -135,5 +137,39 @@ contract CurveFactoryV2Test is Test {
         assertEq(address(treasury), curveFactory.getProtocolTreasury());
         curveFactory.updateProtocolTreasury(address(newTreasury));
         assertEq(address(newTreasury), curveFactory.getProtocolTreasury());
+    }
+
+    function testOwnerSetGlobalFrozen() public {
+        cheats.prank(address(liquidityProvider));
+        ICurveFactory(address(curveFactory)).setGlobalFrozen(true);
+    }
+
+    function testFail_GlobalFrozenDeposit() public {
+        ICurveFactory(address(curveFactory)).setGlobalFrozen(true);
+        
+        cheats.prank(address(liquidityProvider));
+        dfxCadcCurve.deposit(100_000, block.timestamp + 60);
+    }
+
+    function test_GlobalFrozeWithdraw() public {
+        deal(address(cadc), address(liquidityProvider), 100_000e18);
+        deal(address(usdc), address(liquidityProvider), 100_000e6);
+
+        cheats.startPrank(address(liquidityProvider));
+        cadc.approve(address(dfxCadcCurve), type(uint).max);
+        usdc.approve(address(dfxCadcCurve), type(uint).max);
+
+        dfxCadcCurve.deposit(100_000e18, block.timestamp + 60);
+        (uint256 one, uint256[] memory derivatives) = dfxCadcCurve.viewDeposit(100_000e18);
+        cheats.stopPrank();
+
+        assertEq(dfxCadcCurve.balanceOf(address(liquidityProvider)), 100_000e18);
+
+        cheats.prank(address(this));
+        ICurveFactory(address(curveFactory)).setGlobalFrozen(true);
+        
+        // can still withdraw after global freeze
+        cheats.prank(address(liquidityProvider));
+        dfxCadcCurve.withdraw(100_000e18, block.timestamp + 60);
     }
 }

--- a/test/CurveFactoryV2.t.sol
+++ b/test/CurveFactoryV2.t.sol
@@ -139,7 +139,8 @@ contract CurveFactoryV2Test is Test {
         assertEq(address(newTreasury), curveFactory.getProtocolTreasury());
     }
 
-    function testOwnerSetGlobalFrozen() public {
+    // Global Transactable State Frozen
+    function testFail_OwnerSetGlobalFrozen() public {
         cheats.prank(address(liquidityProvider));
         ICurveFactory(address(curveFactory)).setGlobalFrozen(true);
     }

--- a/test/Flashloan.t.sol
+++ b/test/Flashloan.t.sol
@@ -461,4 +461,30 @@ contract FlashloanTest is Test {
 
         curveFlash.initFlash(address(curve), flashData);
     }
+
+    function testFail_GlobalFrozenFlashloans() public {
+        IERC20Detailed token0 = cadc;
+        IERC20Detailed token1 = usdc;
+        Curve curve = dfxCurves[0];
+
+        uint256 dec0 = utils.tenToPowerOf(token0.decimals());
+        uint256 dec1 = utils.tenToPowerOf(token1.decimals());
+
+        deal(address(token0), address(curveFlash), uint256(100_000).mul(dec0));
+        deal(address(token1), address(curveFlash), uint256(100_000).mul(dec1));
+
+        (uint256 one, uint256[] memory derivatives) = ICurve(address(curve)).viewDeposit(100_000e18);
+
+        FlashParams memory flashData = FlashParams({
+            token0: address(token0),
+            token1: address(token1),
+            amount0: derivatives[0],
+            amount1: derivatives[1],
+            decimal0: dec0,
+            decimal1: dec1
+        });
+
+        ICurveFactory(address(curveFactory)).setGlobalFrozen(true);
+        curveFlash.initFlash(address(curve), flashData);
+    }
 }

--- a/test/Flashloan.t.sol
+++ b/test/Flashloan.t.sol
@@ -462,6 +462,7 @@ contract FlashloanTest is Test {
         curveFlash.initFlash(address(curve), flashData);
     }
 
+    // Global Transactable State Frozen
     function testFail_GlobalFrozenFlashloans() public {
         IERC20Detailed token0 = cadc;
         IERC20Detailed token1 = usdc;

--- a/test/Router.t.sol
+++ b/test/Router.t.sol
@@ -316,4 +316,18 @@ contract RouterTest is Test {
 
         routerOriginSwapAndCheck(xsgd, cadc, xsgdOracle, cadcOracle, _amount);
     }
+
+
+    // Global Transactable State Frozen
+    function testFail_GlobalFrozenOriginSwap() public {
+        // Cannot make swaps because global state is frozen
+        ICurveFactory(address(curveFactory)).setGlobalFrozen(true);
+        routerOriginSwapAndCheck(cadc, euroc, cadcOracle, eurocOracle, 100_000);
+    }
+
+     function testFail_GlobalFrozenTargetSwap() public {
+        // Cannot make swaps because global state is frozen
+        ICurveFactory(address(curveFactory)).setGlobalFrozen(true);
+        routerViewTargetSwapAndCheck(euroc, xsgd, usdcOracle, cadcOracle, 100_000);
+    }
 }


### PR DESCRIPTION
# Description
Ontop of an individual freeze on each of the curves there is now a global stopper to freeze all of the contracts at once
# Integrations Checklist

- [ ] Have any function signatures changed? If yes, outline below.
- [ ] Have any features changed or been added? If yes, outline below.
- [ ] Have any events changed or been added? If yes, outline below.
- [ ] Has all documentation been updated?

# Changelog

## Function Signature Changes

## Features

## Events